### PR TITLE
Add SLAXML

### DIFF
--- a/types/SLAXML/slaxdom.d.tl
+++ b/types/SLAXML/slaxdom.d.tl
@@ -17,6 +17,7 @@ local SLAXDOM = record
         type: NodeType
         name: string
         kids: {Node} -- {ProcessingInstruction | Element | Comment}
+        root: Element
     end
 
     Element = record
@@ -24,7 +25,7 @@ local SLAXDOM = record
         name: string
         nsURI: string
         nsPrefix: string
-        attr: {(number | string):Attribute}
+        attr: {string:Attribute} -- FIXME: {string:Attribute} | {Attribute}
         kids: {Node} -- {Element | Text | Comment | ProcessingInstruction}
         el: {Element}
         parent: Node -- Document | Element
@@ -33,12 +34,16 @@ local SLAXDOM = record
     Attribute = record
         type: NodeType
         name: string
+        value: string
+        nsURI: string
+        nsPrefix: string
+        parent: Element
     end
 
     Text = record
         type: NodeType
         name: string
-        cdata: string
+        cdata: boolean
         value: string
         parent: Element
     end

--- a/types/SLAXML/slaxdom.d.tl
+++ b/types/SLAXML/slaxdom.d.tl
@@ -1,76 +1,76 @@
 local SLAXDOM = record
-	NodeType = enum
-		"pi"
-		"comment"
-		"text"
-		"attribute"
-		"element"
-		"document"
-	end
+    NodeType = enum
+        "pi"
+        "comment"
+        "text"
+        "attribute"
+        "element"
+        "document"
+    end
 
-	Node = record
-		type: NodeType
-		name: string
-	end
+    Node = record
+        type: NodeType
+        name: string
+    end
 
-	Document = record
-		type: NodeType
-		name: string
-		kids: {Node} -- {ProcessingInstruction | Element | Comment}
-	end
+    Document = record
+        type: NodeType
+        name: string
+        kids: {Node} -- {ProcessingInstruction | Element | Comment}
+    end
 
-	Element = record
-		type: NodeType
-		name: string
-		nsURI: string
-		nsPrefix: string
-		attr: {(number | string):Attribute}
-		kids: {Node} -- {Element | Text | Comment | ProcessingInstruction}
-		el: {Element}
-		parent: Node -- Document | Element
-	end
+    Element = record
+        type: NodeType
+        name: string
+        nsURI: string
+        nsPrefix: string
+        attr: {(number | string):Attribute}
+        kids: {Node} -- {Element | Text | Comment | ProcessingInstruction}
+        el: {Element}
+        parent: Node -- Document | Element
+    end
 
-	Attribute = record
-		type: NodeType
-		name: string
-	end
+    Attribute = record
+        type: NodeType
+        name: string
+    end
 
-	Text = record
-    	type: NodeType
-    	name: string
-    	cdata: string
-    	value: string
-    	parent: Element
-	end
+    Text = record
+        type: NodeType
+        name: string
+        cdata: string
+        value: string
+        parent: Element
+    end
 
-	Comment = record
-		type: NodeType
-		name: string
-		value: string
-		parent: Node -- Document | Element
-	end
+    Comment = record
+        type: NodeType
+        name: string
+        value: string
+        parent: Node -- Document | Element
+    end
 
-	ProcessingInstruction = record
-		type: NodeType
-		name: string
-		value: string
-		parent: Node -- Document | Element
-	end
+    ProcessingInstruction = record
+        type: NodeType
+        name: string
+        value: string
+        parent: Node -- Document | Element
+    end
 
-	DomConfig = record
-		stripWhitespace: boolean
-		simple: boolean -- TODO: support simple DOM
-	end
+    DomConfig = record
+        stripWhitespace: boolean
+        simple: boolean -- TODO: support simple DOM
+    end
 
-	SerializationConfig = record
-		indent: number | string -- each pi/comment/element/text node on its own line, indented by this many spaces, or supply a custom string to use for indentation
-		sort: boolean -- sort attributes by name, with no-namespace attributes coming first
-		omit: {string} -- an array of namespace URIs; removes elements and attributes in these namespaces
-	end
+    SerializationConfig = record
+        indent: number | string -- each pi/comment/element/text node on its own line, indented by this many spaces, or supply a custom string to use for indentation
+        sort: boolean -- sort attributes by name, with no-namespace attributes coming first
+        omit: {string} -- an array of namespace URIs; removes elements and attributes in these namespaces
+    end
 
-	dom: function(self: SLAXDOM, xml: string, config: DomConfig): Document
+    dom: function(self: SLAXDOM, xml: string, config: DomConfig): Document
 
-	xml: function(self: SLAXDOM, doc: Document, config: SerializationConfig): string
+    xml: function(self: SLAXDOM, doc: Document, config: SerializationConfig): string
 end
 
 return SLAXDOM

--- a/types/SLAXML/slaxdom.d.tl
+++ b/types/SLAXML/slaxdom.d.tl
@@ -1,0 +1,76 @@
+local SLAXDOM = record
+	NodeType = enum
+		"pi"
+		"comment"
+		"text"
+		"attribute"
+		"element"
+		"document"
+	end
+
+	Node = record
+		type: NodeType
+		name: string
+	end
+
+	Document = record
+		type: NodeType
+		name: string
+		kids: {Node} -- {ProcessingInstruction | Element | Comment}
+	end
+
+	Element = record
+		type: NodeType
+		name: string
+		nsURI: string
+		nsPrefix: string
+		attr: {(number | string):Attribute}
+		kids: {Node} -- {Element | Text | Comment | ProcessingInstruction}
+		el: {Element}
+		parent: Node -- Document | Element
+	end
+
+	Attribute = record
+		type: NodeType
+		name: string
+	end
+
+	Text = record
+    	type: NodeType
+    	name: string
+    	cdata: string
+    	value: string
+    	parent: Element
+	end
+
+	Comment = record
+		type: NodeType
+		name: string
+		value: string
+		parent: Node -- Document | Element
+	end
+
+	ProcessingInstruction = record
+		type: NodeType
+		name: string
+		value: string
+		parent: Node -- Document | Element
+	end
+
+	DomConfig = record
+		stripWhitespace: boolean
+		simple: boolean -- TODO: support simple DOM
+	end
+
+	SerializationConfig = record
+		indent: number | string -- each pi/comment/element/text node on its own line, indented by this many spaces, or supply a custom string to use for indentation
+		sort: boolean -- sort attributes by name, with no-namespace attributes coming first
+		omit: {string} -- an array of namespace URIs; removes elements and attributes in these namespaces
+	end
+
+	dom: function(self: SLAXDOM, xml: string, config: DomConfig): Document
+
+	xml: function(self: SLAXDOM, doc: Document, config: SerializationConfig): string
+end
+
+return SLAXDOM

--- a/types/SLAXML/slaxml.d.tl
+++ b/types/SLAXML/slaxml.d.tl
@@ -11,7 +11,7 @@ local SLAXML = record
         startElement: function(name: string, nsURI: string, nsPrefix: string)
         attribute: function(name: string, value: string, nsURI: string, nsPrefix: string)
         closeElement: function(name: string, nsURI: string)
-        text: function(text, cdata: string)
+        text: function(text: string, cdata: boolean)
         comment: function(content: string)
         pi: function(target: string, content: string)
     end

--- a/types/SLAXML/slaxml.d.tl
+++ b/types/SLAXML/slaxml.d.tl
@@ -1,24 +1,24 @@
 local SLAXML = record
-	Parser = record
-		ParserConfig = record
-			stripWhitespace: boolean
-		end
+    Parser = record
+        ParserConfig = record
+            stripWhitespace: boolean
+        end
 
-		parse: function(self: Parser, xml: string, config: ParserConfig)
-	end
+        parse: function(self: Parser, xml: string, config: ParserConfig)
+    end
 
-	ParserCallbacks = record
-		startElement: function(name: string, nsURI: string, nsPrefix: string)
-		attribute: function(name: string, value: string, nsURI: string, nsPrefix: string)
-		closeElement: function(name: string, nsURI: string)
-		text: function(text, cdata: string)
-		comment: function(content: string)
-		pi: function(target: string, content: string)
-	end
+    ParserCallbacks = record
+        startElement: function(name: string, nsURI: string, nsPrefix: string)
+        attribute: function(name: string, value: string, nsURI: string, nsPrefix: string)
+        closeElement: function(name: string, nsURI: string)
+        text: function(text, cdata: string)
+        comment: function(content: string)
+        pi: function(target: string, content: string)
+    end
 
-	parse: function(self: SLAXML, xml: string)
+    parse: function(self: SLAXML, xml: string)
 
-	parser: function(self: SLAXML, callbacks: ParserCallbacks): Parser
+    parser: function(self: SLAXML, callbacks: ParserCallbacks): Parser
 end
 
 return SLAXML

--- a/types/SLAXML/slaxml.d.tl
+++ b/types/SLAXML/slaxml.d.tl
@@ -1,0 +1,24 @@
+local SLAXML = record
+	Parser = record
+		ParserConfig = record
+			stripWhitespace: boolean
+		end
+
+		parse: function(self: Parser, xml: string, config: ParserConfig)
+	end
+
+	ParserCallbacks = record
+		startElement: function(name: string, nsURI: string, nsPrefix: string)
+		attribute: function(name: string, value: string, nsURI: string, nsPrefix: string)
+		closeElement: function(name: string, nsURI: string)
+		text: function(text, cdata: string)
+		comment: function(content: string)
+		pi: function(target: string, content: string)
+	end
+
+	parse: function(self: SLAXML, xml: string)
+
+	parser: function(self: SLAXML, callbacks: ParserCallbacks): Parser
+end
+
+return SLAXML


### PR DESCRIPTION
URL: https://github.com/Phrogz/SLAXML

The library does not appear to be on LuaRocks, although there is a .rockspec file at the root of the repo.

Sadly, it seems like `tl` returns an error when I try to call a method in the SLAXML record. Any idea why?


```lua
-- test.tl
local SLAXML = require 'slaxml'

local myxml = io.open('my.xml'):read('*all')
SLAXML:parse(myxml)
```

```
tl check test.tl
```

```
========================================
1 error:
test.tl:5:14: argument 0: got type {Parser: type {ParserConfig: type {stripWhitespace: boolean}, parse: function(Parser,string,ParserConfig)}, ParserCallbacks: type {startElement: function(string,string,string), attribute: function(string,string,string,string), closeElement: function(string,string), text: function(text,string), comment: function(string), pi: function(string,string)}, parse: function(SLAXML,string), parser: function(SLAXML,ParserCallbacks):Parser}, expected SLAXML
```