### PR TITLE
Add argparse

### DIFF
--- a/types/argparse/argparse.d.tl
+++ b/types/argparse/argparse.d.tl
@@ -1,10 +1,11 @@
 global ArgparseParser = record
 	Argument = record
-		args: function(self: Argument, args: string | number)
-		choices: function(self: Argument, choices: {string})
+		choices: function(self: Argument, choices: {string}): Argument
 
-		convert: function(self: Argument, convert: function | {function})
-		convert: function(self: Argument, convert: {string:string})
+		convert: function(self: Argument, convert: function | {function}): Argument
+		convert: function(self: Argument, convert: {string:string}): Argument
+
+		args: function(self: Argument, args: string | number): Argument
 	end
 
 	Option = record
@@ -14,6 +15,10 @@ global ArgparseParser = record
 		argname: function(self: Option, argname: string): Option
 
 		count: function(self: Option, count: number | string): Option
+
+		target: function(self: Option, target: string): Option
+
+		args: function(self: Option, args: string|number): Option
 	end
 
 	Command = record

--- a/types/argparse/argparse.d.tl
+++ b/types/argparse/argparse.d.tl
@@ -1,0 +1,52 @@
+local Parser = record
+	Argument = record
+		args: function(self: Argument, args: string | number)
+		choices: function(self: Argument, choices: {string})
+
+		convert: function(self: Argument, convert: function | {function})
+		convert: function(self: Argument, convert: {string:string})
+	end
+
+	Option = record
+		name: function(self: Option, name: string): Option
+		description: function(self: Option, description: string): Option
+
+		argname: function(self: Option, argname: string): Option
+
+		count: function(self: Option, count: number | string): Option
+	end
+
+	Command = record
+		summary: function(self: Command, summary: string): Command
+		description: function(self: Command, description: string): Command
+
+		argument: function(self: Command, name: string, description: string): Argument
+	end
+
+	-- FIXME: the config can also be set by calling the parser as a function
+	name: function(self: Parser, name: string): Parser
+	description: function(self: Parser, description: string): Parser
+	epilog: function(self: Parser, epilog: string): Parser
+
+	flag: function(self: Parser, flag: string): Option
+	flag: function(self: Parser, shortalias: string, longalias: string): Option
+
+	parse: function(self: Parser, argv: {string})
+	pparse: function(self: Parser, argv: {string}): boolean, string
+
+	error: function(self: Parser, error: string)
+
+	argument: function(self: Parser, name: string, description: string)
+
+	option: function(self: Parser, name: string, description: string, default: string, convert: function | {function}, args: {string}, count: number | string): Option
+	option: function(self: Parser, name: string, description: string, default: string, convert: {string:string}, args: {string}, count: number | string): Option
+
+	require_command: function(self: Parser, require_command: boolean): Parser
+	command_target: function(self: Parser, command_target: string): Parser
+
+	command: function(self: Parser, name: string, description: string, epilog: string): Command
+end
+
+local argparse: function(name: string, description: string, epilog: string): Parser
+
+return argparse

--- a/types/argparse/argparse.d.tl
+++ b/types/argparse/argparse.d.tl
@@ -1,4 +1,4 @@
-local Parser = record
+global ArgparseParser = record
 	Argument = record
 		args: function(self: Argument, args: string | number)
 		choices: function(self: Argument, choices: {string})
@@ -24,29 +24,29 @@ local Parser = record
 	end
 
 	-- FIXME: the config can also be set by calling the parser as a function
-	name: function(self: Parser, name: string): Parser
-	description: function(self: Parser, description: string): Parser
-	epilog: function(self: Parser, epilog: string): Parser
+	name: function(self: ArgparseParser, name: string): ArgparseParser
+	description: function(self: ArgparseParser, description: string): ArgparseParser
+	epilog: function(self: ArgparseParser, epilog: string): ArgparseParser
 
-	flag: function(self: Parser, flag: string): Option
-	flag: function(self: Parser, shortalias: string, longalias: string): Option
+	flag: function(self: ArgparseParser, flag: string): Option
+	flag: function(self: ArgparseParser, shortalias: string, longalias: string): Option
 
-	parse: function(self: Parser, argv: {string})
-	pparse: function(self: Parser, argv: {string}): boolean, string
+	parse: function(self: ArgparseParser, argv: {string})
+	pparse: function(self: ArgparseParser, argv: {string}): boolean, string
 
-	error: function(self: Parser, error: string)
+	error: function(self: ArgparseParser, error: string)
 
-	argument: function(self: Parser, name: string, description: string)
+	argument: function(self: ArgparseParser, name: string, description: string)
 
-	option: function(self: Parser, name: string, description: string, default: string, convert: function | {function}, args: {string}, count: number | string): Option
-	option: function(self: Parser, name: string, description: string, default: string, convert: {string:string}, args: {string}, count: number | string): Option
+	option: function(self: ArgparseParser, name: string, description: string, default: string, convert: function | {function}, args: {string}, count: number | string): Option
+	option: function(self: ArgparseParser, name: string, description: string, default: string, convert: {string:string}, args: {string}, count: number | string): Option
 
-	require_command: function(self: Parser, require_command: boolean): Parser
-	command_target: function(self: Parser, command_target: string): Parser
+	require_command: function(self: ArgparseParser, require_command: boolean): ArgparseParser
+	command_target: function(self: ArgparseParser, command_target: string): ArgparseParser
 
-	command: function(self: Parser, name: string, description: string, epilog: string): Command
+	command: function(self: ArgparseParser, name: string, description: string, epilog: string): Command
 end
 
-local argparse: function(name: string, description: string, epilog: string): Parser
+local argparse: function(name: string, description: string, epilog: string): ArgparseParser
 
 return argparse

--- a/types/argparse/argparse.d.tl
+++ b/types/argparse/argparse.d.tl
@@ -31,8 +31,8 @@ global ArgparseParser = record
 	flag: function(self: ArgparseParser, flag: string): Option
 	flag: function(self: ArgparseParser, shortalias: string, longalias: string): Option
 
-	parse: function(self: ArgparseParser, argv: {string})
-	pparse: function(self: ArgparseParser, argv: {string}): boolean, string
+	parse: function(self: ArgparseParser, argv: {string}): {string:{string}|string|boolean}
+	pparse: function(self: ArgparseParser, argv: {string}): boolean, {string:{string}|string|boolean} | string
 
 	error: function(self: ArgparseParser, error: string)
 


### PR DESCRIPTION
The definition is not complete yet, but I think it handles the basics.

There is no way to express that it returns a table with a `__call` metamethod, so we simulate it by returning a function.