### PR TITLE
inspect: use __call metamethod

### DIFF
--- a/types/inspect/inspect.d.tl
+++ b/types/inspect/inspect.d.tl
@@ -1,10 +1,12 @@
-global record InspectOptions
-    depth: number
-    newline: string
-    indent: string
-    process: function(item: any, path: {any}): any
-end
+local record inspect
+    record InspectOptions
+        depth: number
+        newline: string
+        indent: string
+        process: function(item: any, path: {any}): any
+    end
 
-local inspect: function(value: any, options: InspectOptions): string
+    metamethod __call: function(self: inspect, value: any, options: InspectOptions): string
+end
 
 return inspect


### PR DESCRIPTION
The `inspect` library returns a table with a `__call` metamethod. Yet, when `inspect.d.tl` was written, `tl` didn't support metamethods, so we had to approximate it with a function.

This PR:

- Converts the `inspect` function into an `inspect` record with a `__call` metamethod
- Replaces the global `InspectOptions` with a nested record: `inspect.InspectOptions`