### PR TITLE
add vim.tbl_deep_extend function

### DIFF
--- a/types/neovim/vim.d.tl
+++ b/types/neovim/vim.d.tl
@@ -74,6 +74,7 @@ global record vim
       "force"
    end
    tbl_extend: function(ExtendBehavior, table, table, ...: table): table
+   tbl_deep_extend: function(ExtendBehavior, table, table, ...: table): table
 
    tbl_flatten: function<T>({T|{T}}): {T}
    tbl_flatten: function({any|{any}}): {any}


### PR DESCRIPTION
This adds the `vim.tbl_deep_extend` function from the neovim api.