### PR TITLE
Upgrade neovim to 0.6

### DIFF
--- a/types/neovim/template
+++ b/types/neovim/template
@@ -74,6 +74,7 @@ global record vim
    endswith: function(string, string): boolean
    gsplit: function(string, string, boolean): function(): string
    is_callable: function(any): boolean
+   list_extend: function<T>({T}, {T}, number, number): {T}
    list_extend: function<T, K>({T}, {K}, number, number): {T|K}
    list_slice: function<T>({T}, number, number): {T}
    pesc: function(string): string

--- a/types/neovim/template
+++ b/types/neovim/template
@@ -366,7 +366,7 @@ global record vim
       end
       config: function(opts: ConfigOpts, namespace: integer|nil)
       disable: function(bufnr: integer|nil, namespace: integer|nil)
-      disable: function(bufnr: integer|nil, namespace: integer|nil)
+      enable: function(bufnr: integer|nil, namespace: integer|nil)
       fromqflist: function(list: {any}): {Diagnostic}
       get: function(bufnr: integer|nil, opts: GetOpts)
       get_namespace: function(namespace: integer): {string:integer}

--- a/types/neovim/template
+++ b/types/neovim/template
@@ -12,6 +12,8 @@ global record vim
    --    ...
    -- end
    fn: {string:function(...: any): (any)}
+   cmd: function(cmd: string)
+   call: function(func: string, ...: any)
 
    enum Mode
       "n" -- Normal
@@ -52,6 +54,17 @@ global record vim
       process: function
    end
    inspect: function(any, InspectOptions): string
+
+   record log
+      record levels
+         DEBUG: integer
+         INFO: integer
+         HINT: integer
+         WARN: integer
+         ERROR: integer
+      end
+   end
+   notify: function(msg: string, log_level: integer, opts: table|nil)
    paste: function({string}, number): boolean
    schedule_wrap: function(function): function
    deep_equal: function(any, any): boolean
@@ -62,6 +75,7 @@ global record vim
    gsplit: function(string, string, boolean): function(): string
    is_callable: function(any): boolean
    list_extend: function<T, K>({T}, {K}, number, number): {T|K}
+   list_slice: function<T>({T}, number, number): {T}
    pesc: function(string): string
    split: function(string, string, boolean): {string}
    wait: function(integer)
@@ -69,12 +83,24 @@ global record vim
    tbl_add_reverse_lookup: function(table)
    tbl_contains: function<T>({T}, T): boolean
 
+   tbl_count: function(table): integer
+
    enum ExtendBehavior
       "error"
       "keep"
       "force"
    end
    tbl_extend: function(ExtendBehavior, table, table, ...: table): table
+   tbl_extend: function<T>(ExtendBehavior, {T:any}, {T:any}, ...: {T:any}): {T:any}
+   tbl_extend: function<T>(ExtendBehavior, {any:T}, {any:T}, ...: {any:T}): {any:T}
+   tbl_extend: function<T,V>(ExtendBehavior, {T:V}, {T:V}, ...: {T:V}): {T:V}
+   tbl_deep_extend: function(ExtendBehavior, table, table, ...: table): table
+   tbl_deep_extend: function<T>(ExtendBehavior, {T:any}, {T:any}, ...: {T:any}): {T:any}
+   tbl_deep_extend: function<T>(ExtendBehavior, {any:T}, {any:T}, ...: {any:T}): {any:T}
+   tbl_deep_extend: function<T,V>(ExtendBehavior, {T:V}, {T:V}, ...: {T:V}): {T:V}
+
+   tbl_filter: function<T>(function(T): (boolean), {T})
+   tbl_filter: function(function(any): (boolean), {any})
 
    tbl_flatten: function<T>({T|{T}}): {T}
    tbl_flatten: function({any|{any}}): {any}
@@ -240,7 +266,7 @@ global record vim
       end
       on_yank: function(Opts)
       range: function(
-         bufnr: number,
+         bufnr: integer,
          ns: number,
          higroup: string,
          start: {number, number},
@@ -250,25 +276,121 @@ global record vim
       )
    end
 
-   record lsp
-      record diagnostic
-         record ShowLineOpts
-            focusable: boolean
-            show_header: boolean
-         end
-         goto_prev: function
-         goto_next: function
-         show_line_diagnostics: function(ShowLineOpts, number, number, number): number, number
+   record diagnostic
+      record Severity -- would be great if this could be a tuplerecord
+         {string}
+         ERROR: integer
+         WARN: integer
+         INFO: integer
+         HINT: integer
+         E: integer
+         W: integer
+         I: integer
+         H: integer
       end
+      severity: Severity
+
+      record Diagnostic
+         lnum: integer -- The starting line of the diagnostic
+         end_lnum: integer -- The final line of the diagnostic
+         col: integer -- The starting column of the diagnostic
+         end_col: integer -- The final column of the diagnostic
+         severity: integer -- The severity of the diagnostic |vim.diagnostic.severity|
+         message: string -- The diagnostic text
+         source: string -- The source of the diagnostic
+      end
+      record ConfigOpts
+         record UnderlineOpts
+            severity: integer -- vim.diagnostic.severity
+         end
+         record VirtualTextOpts
+            severity: integer -- vim.diagnostic.severity
+            source: string
+            format: function(diagnostic: Diagnostic): string
+         end
+         record SignsOpts
+            severity: integer
+            priority: integer
+         end
+
+         underline: boolean|UnderlineOpts
+         virtual_text: boolean|VirtualTextOpts
+         signs: boolean|SignsOpts
+         float: OpenFloatOpts
+         update_in_insert: boolean
+         severity_sort: boolean
+      end
+      record GetOpts
+         namespace: integer
+         lnum: integer
+         severity: integer -- vim.diagnostic.severity
+      end
+      record GotoOpts
+         namespace: integer
+         cursor_position: {integer, integer}
+         wrap: boolean
+         severity: integer -- vim.diagnostic.severity
+         float: boolean|OpenFloatOpts
+         win_id: integer
+      end
+      record OpenFloatOpts
+         namespace: integer
+         scope: string -- "buffer", "line" or "cursor"
+         pos: integer|{integer, integer}
+         severity_sort: boolean
+         severity: integer -- vim.diagnostic.severity
+         header: string|{string, string}
+         source: string
+         format: function(diagnostic: Diagnostic): string
+         prefix: string|{string, string}|function(diagnostic: Diagnostic, i: integer, total: integer): string, string|nil
+      end
+      record SetLocListOpts
+         namespace: integer
+         winnr: integer
+         open: boolean
+         title: string
+         severity: integer -- vim.diagnostic.severity
+      end
+      record SetQfListOpts
+         namespace: integer
+         open: boolean
+         title: string
+         severity: integer -- vim.diagnostic.severity
+      end
+      config: function(opts: ConfigOpts, namespace: integer|nil)
+      disable: function(bufnr: integer|nil, namespace: integer|nil)
+      disable: function(bufnr: integer|nil, namespace: integer|nil)
+      fromqflist: function(list: {any}): {Diagnostic}
+      get: function(bufnr: integer|nil, opts: GetOpts)
+      get_namespace: function(namespace: integer): {string:integer}
+      get_namespace: function(namespace: integer): {{string:integer}}
+      get_next: function(opts: GotoOpts): Diagnostic
+      get_next_pos: function(opts: GotoOpts): {integer, integer}
+      get_prev: function(opts: GotoOpts): Diagnostic
+      get_prev_pos: function(opts: GotoOpts): {integer, integer}
+      goto_next: function(opts: GotoOpts)
+      goto_prev: function(opts: GotoOpts)
+      hide: function(namespace: integer|nil, bufnr: integer|nil)
+      match: function(str: string, pat: string, groups: {string}, severity_map: {string:string}, defaults: {string:any}): Diagnostic|nil
+      open_float: function(bufnr: integer|nil, opts: OpenFloatOpts): {integer, integer}
+      reset: function(namespace: integer|nil, bufnr: integer|nil)
+      set: function(namespace: integer, bufnr: integer, diagnostics: {Diagnostic}, opts: ConfigOpts|nil)
+      setloclist: function(opts: SetLocListOpts)
+      setqflist: function(opts: SetQfListOpts)
+      show: function(namespace: integer|nil, bufnr: integer|nil, diagnostics: {Diagnostic}|nil, opts: ConfigOpts|nil)
+      toqflist: function({Diagnostic}): {string:any}
+   end
+
+   record lsp
       record buf
          hover: function
       end
-      buf_attach_client: function(bufnr: number, client_id: number)
-      buf_get_clients: function(bufnr: number)
-      buf_is_attached: function(bufnr: number, client_id: number)
-      buf_notify: function(bufnr: number, method: string, params: string): boolean
-      buf_request: function(bufnr: number, method: string, params: table, handler: function): {number:number}, function
-      buf_request_sync: function(bufnr: number, method: string, params: table, timeout_ms: number): {number:number}, string
+      buf_attach_client: function(bufnr: integer, client_id: integer)
+      buf_get_clients: function(bufnr: integer)
+      buf_is_attached: function(bufnr: integer, client_id: integer)
+      buf_notify: function(bufnr: integer, method: string, params: string): boolean
+      buf_request: function(bufnr: integer, method: string, params: table, handler: function): {number:number}, function
+      buf_request_sync: function(bufnr: integer, method: string, params: table, timeout_ms: number): {number:number}, string
 
       record Client
          request: function(Client)

--- a/types/neovim/template
+++ b/types/neovim/template
@@ -415,5 +415,19 @@ global record vim
    wo: WindowOptions
 
    --[[$API$]]
+
+   record json
+      record DecodeOpts
+         record Luanil
+            object: boolean
+            array: boolean
+         end
+
+         luanil: Luanil
+      end
+
+      encode: function(string)
+      decode: function(string, DecodeOpts)
+   end
 end
 

--- a/types/neovim/template
+++ b/types/neovim/template
@@ -64,7 +64,7 @@ global record vim
          ERROR: integer
       end
    end
-   notify: function(msg: string, log_level: integer, opts: table|nil)
+   notify: function(msg: string, log_level: integer, opts: table)
    paste: function({string}, number): boolean
    schedule_wrap: function(function): function
    deep_equal: function(any, any): boolean
@@ -349,7 +349,7 @@ global record vim
          header: string|{string, string}
          source: string
          format: function(diagnostic: Diagnostic): string
-         prefix: string|{string, string}|function(diagnostic: Diagnostic, i: integer, total: integer): string, string|nil
+         prefix: string|{string, string}|function(diagnostic: Diagnostic, i: integer, total: integer): string, string
       end
       record SetLocListOpts
          namespace: integer
@@ -364,11 +364,11 @@ global record vim
          title: string
          severity: integer -- vim.diagnostic.severity
       end
-      config: function(opts: ConfigOpts, namespace: integer|nil)
-      disable: function(bufnr: integer|nil, namespace: integer|nil)
-      enable: function(bufnr: integer|nil, namespace: integer|nil)
+      config: function(opts: ConfigOpts, namespace: integer)
+      disable: function(bufnr: integer, namespace: integer)
+      enable: function(bufnr: integer, namespace: integer)
       fromqflist: function(list: {any}): {Diagnostic}
-      get: function(bufnr: integer|nil, opts: GetOpts)
+      get: function(bufnr: integer, opts: GetOpts)
       get_namespace: function(namespace: integer): {string:integer}
       get_namespace: function(namespace: integer): {{string:integer}}
       get_next: function(opts: GotoOpts): Diagnostic
@@ -377,14 +377,14 @@ global record vim
       get_prev_pos: function(opts: GotoOpts): {integer, integer}
       goto_next: function(opts: GotoOpts)
       goto_prev: function(opts: GotoOpts)
-      hide: function(namespace: integer|nil, bufnr: integer|nil)
-      match: function(str: string, pat: string, groups: {string}, severity_map: {string:string}, defaults: {string:any}): Diagnostic|nil
-      open_float: function(bufnr: integer|nil, opts: OpenFloatOpts): {integer, integer}
-      reset: function(namespace: integer|nil, bufnr: integer|nil)
-      set: function(namespace: integer, bufnr: integer, diagnostics: {Diagnostic}, opts: ConfigOpts|nil)
+      hide: function(namespace: integer, bufnr: integer)
+      match: function(str: string, pat: string, groups: {string}, severity_map: {string:string}, defaults: {string:any}): Diagnostic
+      open_float: function(bufnr: integer, opts: OpenFloatOpts): {integer, integer}
+      reset: function(namespace: integer, bufnr: integer)
+      set: function(namespace: integer, bufnr: integer, diagnostics: {Diagnostic}, opts: ConfigOpts)
       setloclist: function(opts: SetLocListOpts)
       setqflist: function(opts: SetQfListOpts)
-      show: function(namespace: integer|nil, bufnr: integer|nil, diagnostics: {Diagnostic}|nil, opts: ConfigOpts|nil)
+      show: function(namespace: integer, bufnr: integer, diagnostics: {Diagnostic}, opts: ConfigOpts)
       toqflist: function({Diagnostic}): {string:any}
    end
 

--- a/types/neovim/template
+++ b/types/neovim/template
@@ -335,8 +335,14 @@ global record vim
          win_id: integer
       end
       record OpenFloatOpts
+         enum Scope
+            "buffer"
+            "line"
+            "cursor"
+         end
+
          namespace: integer
-         scope: string -- "buffer", "line" or "cursor"
+         scope: Scope
          pos: integer|{integer, integer}
          severity_sort: boolean
          severity: integer -- vim.diagnostic.severity

--- a/types/neovim/vim.d.tl
+++ b/types/neovim/vim.d.tl
@@ -830,5 +830,19 @@ global record vim
       nvim_win_set_width: function(integer--[[Window]], integer--[[Integer]])--[[void]]
    end
 
+
+   record json
+      record DecodeOpts
+         record Luanil
+            object: boolean
+            array: boolean
+         end
+
+         luanil: Luanil
+      end
+
+      encode: function(string)
+      decode: function(string, DecodeOpts)
+   end
 end
 

--- a/types/neovim/vim.d.tl
+++ b/types/neovim/vim.d.tl
@@ -74,6 +74,7 @@ global record vim
    endswith: function(string, string): boolean
    gsplit: function(string, string, boolean): function(): string
    is_callable: function(any): boolean
+   list_extend: function<T>({T}, {T}, number, number): {T}
    list_extend: function<T, K>({T}, {K}, number, number): {T|K}
    list_slice: function<T>({T}, number, number): {T}
    pesc: function(string): string

--- a/types/neovim/vim.d.tl
+++ b/types/neovim/vim.d.tl
@@ -335,8 +335,14 @@ global record vim
          win_id: integer
       end
       record OpenFloatOpts
+         enum Scope
+            "buffer"
+            "line"
+            "cursor"
+         end
+
          namespace: integer
-         scope: string -- "buffer", "line" or "cursor"
+         scope: Scope
          pos: integer|{integer, integer}
          severity_sort: boolean
          severity: integer -- vim.diagnostic.severity
@@ -360,7 +366,7 @@ global record vim
       end
       config: function(opts: ConfigOpts, namespace: integer|nil)
       disable: function(bufnr: integer|nil, namespace: integer|nil)
-      disable: function(bufnr: integer|nil, namespace: integer|nil)
+      enable: function(bufnr: integer|nil, namespace: integer|nil)
       fromqflist: function(list: {any}): {Diagnostic}
       get: function(bufnr: integer|nil, opts: GetOpts)
       get_namespace: function(namespace: integer): {string:integer}

--- a/types/neovim/vim.d.tl
+++ b/types/neovim/vim.d.tl
@@ -12,6 +12,8 @@ global record vim
    --    ...
    -- end
    fn: {string:function(...: any): (any)}
+   cmd: function(cmd: string)
+   call: function(func: string, ...: any)
 
    enum Mode
       "n" -- Normal
@@ -52,6 +54,17 @@ global record vim
       process: function
    end
    inspect: function(any, InspectOptions): string
+
+   record log
+      record levels
+         DEBUG: integer
+         INFO: integer
+         HINT: integer
+         WARN: integer
+         ERROR: integer
+      end
+   end
+   notify: function(msg: string, log_level: integer, opts: table|nil)
    paste: function({string}, number): boolean
    schedule_wrap: function(function): function
    deep_equal: function(any, any): boolean
@@ -62,6 +75,7 @@ global record vim
    gsplit: function(string, string, boolean): function(): string
    is_callable: function(any): boolean
    list_extend: function<T, K>({T}, {K}, number, number): {T|K}
+   list_slice: function<T>({T}, number, number): {T}
    pesc: function(string): string
    split: function(string, string, boolean): {string}
    wait: function(integer)
@@ -69,12 +83,24 @@ global record vim
    tbl_add_reverse_lookup: function(table)
    tbl_contains: function<T>({T}, T): boolean
 
+   tbl_count: function(table): integer
+
    enum ExtendBehavior
       "error"
       "keep"
       "force"
    end
    tbl_extend: function(ExtendBehavior, table, table, ...: table): table
+   tbl_extend: function<T>(ExtendBehavior, {T:any}, {T:any}, ...: {T:any}): {T:any}
+   tbl_extend: function<T>(ExtendBehavior, {any:T}, {any:T}, ...: {any:T}): {any:T}
+   tbl_extend: function<T,V>(ExtendBehavior, {T:V}, {T:V}, ...: {T:V}): {T:V}
+   tbl_deep_extend: function(ExtendBehavior, table, table, ...: table): table
+   tbl_deep_extend: function<T>(ExtendBehavior, {T:any}, {T:any}, ...: {T:any}): {T:any}
+   tbl_deep_extend: function<T>(ExtendBehavior, {any:T}, {any:T}, ...: {any:T}): {any:T}
+   tbl_deep_extend: function<T,V>(ExtendBehavior, {T:V}, {T:V}, ...: {T:V}): {T:V}
+
+   tbl_filter: function<T>(function(T): (boolean), {T})
+   tbl_filter: function(function(any): (boolean), {any})
 
    tbl_flatten: function<T>({T|{T}}): {T}
    tbl_flatten: function({any|{any}}): {any}
@@ -240,7 +266,7 @@ global record vim
       end
       on_yank: function(Opts)
       range: function(
-         bufnr: number,
+         bufnr: integer,
          ns: number,
          higroup: string,
          start: {number, number},
@@ -250,25 +276,121 @@ global record vim
       )
    end
 
-   record lsp
-      record diagnostic
-         record ShowLineOpts
-            focusable: boolean
-            show_header: boolean
-         end
-         goto_prev: function
-         goto_next: function
-         show_line_diagnostics: function(ShowLineOpts, number, number, number): number, number
+   record diagnostic
+      record Severity -- would be great if this could be a tuplerecord
+         {string}
+         ERROR: integer
+         WARN: integer
+         INFO: integer
+         HINT: integer
+         E: integer
+         W: integer
+         I: integer
+         H: integer
       end
+      severity: Severity
+
+      record Diagnostic
+         lnum: integer -- The starting line of the diagnostic
+         end_lnum: integer -- The final line of the diagnostic
+         col: integer -- The starting column of the diagnostic
+         end_col: integer -- The final column of the diagnostic
+         severity: integer -- The severity of the diagnostic |vim.diagnostic.severity|
+         message: string -- The diagnostic text
+         source: string -- The source of the diagnostic
+      end
+      record ConfigOpts
+         record UnderlineOpts
+            severity: integer -- vim.diagnostic.severity
+         end
+         record VirtualTextOpts
+            severity: integer -- vim.diagnostic.severity
+            source: string
+            format: function(diagnostic: Diagnostic): string
+         end
+         record SignsOpts
+            severity: integer
+            priority: integer
+         end
+
+         underline: boolean|UnderlineOpts
+         virtual_text: boolean|VirtualTextOpts
+         signs: boolean|SignsOpts
+         float: OpenFloatOpts
+         update_in_insert: boolean
+         severity_sort: boolean
+      end
+      record GetOpts
+         namespace: integer
+         lnum: integer
+         severity: integer -- vim.diagnostic.severity
+      end
+      record GotoOpts
+         namespace: integer
+         cursor_position: {integer, integer}
+         wrap: boolean
+         severity: integer -- vim.diagnostic.severity
+         float: boolean|OpenFloatOpts
+         win_id: integer
+      end
+      record OpenFloatOpts
+         namespace: integer
+         scope: string -- "buffer", "line" or "cursor"
+         pos: integer|{integer, integer}
+         severity_sort: boolean
+         severity: integer -- vim.diagnostic.severity
+         header: string|{string, string}
+         source: string
+         format: function(diagnostic: Diagnostic): string
+         prefix: string|{string, string}|function(diagnostic: Diagnostic, i: integer, total: integer): string, string|nil
+      end
+      record SetLocListOpts
+         namespace: integer
+         winnr: integer
+         open: boolean
+         title: string
+         severity: integer -- vim.diagnostic.severity
+      end
+      record SetQfListOpts
+         namespace: integer
+         open: boolean
+         title: string
+         severity: integer -- vim.diagnostic.severity
+      end
+      config: function(opts: ConfigOpts, namespace: integer|nil)
+      disable: function(bufnr: integer|nil, namespace: integer|nil)
+      disable: function(bufnr: integer|nil, namespace: integer|nil)
+      fromqflist: function(list: {any}): {Diagnostic}
+      get: function(bufnr: integer|nil, opts: GetOpts)
+      get_namespace: function(namespace: integer): {string:integer}
+      get_namespace: function(namespace: integer): {{string:integer}}
+      get_next: function(opts: GotoOpts): Diagnostic
+      get_next_pos: function(opts: GotoOpts): {integer, integer}
+      get_prev: function(opts: GotoOpts): Diagnostic
+      get_prev_pos: function(opts: GotoOpts): {integer, integer}
+      goto_next: function(opts: GotoOpts)
+      goto_prev: function(opts: GotoOpts)
+      hide: function(namespace: integer|nil, bufnr: integer|nil)
+      match: function(str: string, pat: string, groups: {string}, severity_map: {string:string}, defaults: {string:any}): Diagnostic|nil
+      open_float: function(bufnr: integer|nil, opts: OpenFloatOpts): {integer, integer}
+      reset: function(namespace: integer|nil, bufnr: integer|nil)
+      set: function(namespace: integer, bufnr: integer, diagnostics: {Diagnostic}, opts: ConfigOpts|nil)
+      setloclist: function(opts: SetLocListOpts)
+      setqflist: function(opts: SetQfListOpts)
+      show: function(namespace: integer|nil, bufnr: integer|nil, diagnostics: {Diagnostic}|nil, opts: ConfigOpts|nil)
+      toqflist: function({Diagnostic}): {string:any}
+   end
+
+   record lsp
       record buf
          hover: function
       end
-      buf_attach_client: function(bufnr: number, client_id: number)
-      buf_get_clients: function(bufnr: number)
-      buf_is_attached: function(bufnr: number, client_id: number)
-      buf_notify: function(bufnr: number, method: string, params: string): boolean
-      buf_request: function(bufnr: number, method: string, params: table, handler: function): {number:number}, function
-      buf_request_sync: function(bufnr: number, method: string, params: table, timeout_ms: number): {number:number}, string
+      buf_attach_client: function(bufnr: integer, client_id: integer)
+      buf_get_clients: function(bufnr: integer)
+      buf_is_attached: function(bufnr: integer, client_id: integer)
+      buf_notify: function(bufnr: integer, method: string, params: string): boolean
+      buf_request: function(bufnr: integer, method: string, params: table, handler: function): {number:number}, function
+      buf_request_sync: function(bufnr: integer, method: string, params: table, timeout_ms: number): {number:number}, string
 
       record Client
          request: function(Client)
@@ -428,8 +550,10 @@ global record vim
       textwidth: number
       tfu: string
       thesaurus: string
+      thesaurusfunc: string
       ts: number
       tsr: string
+      tsrfu: string
       tw: number
       udf: boolean
       ul: number
@@ -461,9 +585,11 @@ global record vim
       crb: boolean
       cuc: boolean
       cul: boolean
+      culopt: string
       cursorbind: boolean
       cursorcolumn: boolean
       cursorline: boolean
+      cursorlineopt: string
       diff: boolean
       fcs: string
       fdc: string
@@ -504,12 +630,14 @@ global record vim
       rl: boolean
       rlc: string
       rnu: boolean
+      sbr: string
       scb: boolean
       scl: string
       scr: number
       scroll: number
       scrollbind: boolean
       scrolloff: number
+      showbreak: string
       sidescrolloff: number
       signcolumn: string
       siso: number
@@ -533,10 +661,10 @@ global record vim
    record api
       --[[
          API version Information
-            neovim version: 0.5.1
+            neovim version: 0.6.0
 
             compatible: 0
-            level: 7
+            level: 8
             prerelease: false
       --]]
 
@@ -560,6 +688,7 @@ global record vim
       nvim_buf_clear_namespace: function(integer--[[Buffer]], integer--[[Integer]], integer--[[Integer]], integer--[[Integer]])--[[void]]
       nvim_buf_del_extmark: function(integer--[[Buffer]], integer--[[Integer]], integer--[[Integer]]): boolean--[[Boolean]]
       nvim_buf_del_keymap: function(integer--[[Buffer]], string--[[String]], string--[[String]])--[[void]]
+      nvim_buf_del_mark: function(integer--[[Buffer]], string--[[String]]): boolean--[[Boolean]]
       nvim_buf_del_var: function(integer--[[Buffer]], string--[[String]])--[[void]]
       nvim_buf_delete: function(integer--[[Buffer]], {string:any}--[[Dictionary]])--[[void]]
       nvim_buf_detach: function(integer--[[Buffer]]): boolean--[[Boolean]]
@@ -580,11 +709,11 @@ global record vim
       nvim_buf_set_extmark: function(integer--[[Buffer]], integer--[[Integer]], integer--[[Integer]], integer--[[Integer]], {string:any}--[[Dictionary]]): integer--[[Integer]]
       nvim_buf_set_keymap: function(integer--[[Buffer]], string--[[String]], string--[[String]], string--[[String]], {string:any}--[[Dictionary]])--[[void]]
       nvim_buf_set_lines: function(integer--[[Buffer]], integer--[[Integer]], integer--[[Integer]], boolean--[[Boolean]], {string}--[[ArrayOf(String)]])--[[void]]
+      nvim_buf_set_mark: function(integer--[[Buffer]], string--[[String]], integer--[[Integer]], integer--[[Integer]], {string:any}--[[Dictionary]]): boolean--[[Boolean]]
       nvim_buf_set_name: function(integer--[[Buffer]], string--[[String]])--[[void]]
       nvim_buf_set_option: function(integer--[[Buffer]], string--[[String]], any--[[Object]])--[[void]]
       nvim_buf_set_text: function(integer--[[Buffer]], integer--[[Integer]], integer--[[Integer]], integer--[[Integer]], integer--[[Integer]], {string}--[[ArrayOf(String)]])--[[void]]
       nvim_buf_set_var: function(integer--[[Buffer]], string--[[String]], any--[[Object]])--[[void]]
-      nvim_buf_set_virtual_text: function(integer--[[Buffer]], integer--[[Integer]], integer--[[Integer]], any--[[Array]], {string:any}--[[Dictionary]]): integer--[[Integer]]
       nvim_call_atomic: function(any--[[Array]]): any--[[Array]]
       nvim_call_dict_function: function(any--[[Object]], string--[[String]], any--[[Array]]): any--[[Object]]
       nvim_call_function: function(string--[[String]], any--[[Array]]): any--[[Object]]
@@ -594,11 +723,13 @@ global record vim
       nvim_create_namespace: function(string--[[String]]): integer--[[Integer]]
       nvim_del_current_line: function()--[[void]]
       nvim_del_keymap: function(string--[[String]], string--[[String]])--[[void]]
+      nvim_del_mark: function(string--[[String]]): boolean--[[Boolean]]
       nvim_del_var: function(string--[[String]])--[[void]]
       nvim_echo: function(any--[[Array]], boolean--[[Boolean]], {string:any}--[[Dictionary]])--[[void]]
       nvim_err_write: function(string--[[String]])--[[void]]
       nvim_err_writeln: function(string--[[String]])--[[void]]
       nvim_eval: function(string--[[String]]): any--[[Object]]
+      nvim_eval_statusline: function(string--[[String]], {string:any}--[[Dictionary]]): {string:any}--[[Dictionary]]
       nvim_exec: function(string--[[String]], boolean--[[Boolean]]): string--[[String]]
       nvim_exec_lua: function(string--[[String]], any--[[Array]]): any--[[Object]]
       nvim_feedkeys: function(string--[[String]], string--[[String]], boolean--[[Boolean]])--[[void]]
@@ -617,6 +748,7 @@ global record vim
       nvim_get_hl_by_name: function(string--[[String]], boolean--[[Boolean]]): {string:any}--[[Dictionary]]
       nvim_get_hl_id_by_name: function(string--[[String]]): integer--[[Integer]]
       nvim_get_keymap: function(string--[[String]]): {{string:any}}--[[ArrayOf(Dictionary)]]
+      nvim_get_mark: function(string--[[String]], {string:any}--[[Dictionary]]): any--[[Array]]
       nvim_get_mode: function(): {string:any}--[[Dictionary]]
       nvim_get_namespaces: function(): {string:any}--[[Dictionary]]
       nvim_get_option: function(string--[[String]]): any--[[Object]]

--- a/types/neovim/vim.d.tl
+++ b/types/neovim/vim.d.tl
@@ -64,7 +64,7 @@ global record vim
          ERROR: integer
       end
    end
-   notify: function(msg: string, log_level: integer, opts: table|nil)
+   notify: function(msg: string, log_level: integer, opts: table)
    paste: function({string}, number): boolean
    schedule_wrap: function(function): function
    deep_equal: function(any, any): boolean
@@ -349,7 +349,7 @@ global record vim
          header: string|{string, string}
          source: string
          format: function(diagnostic: Diagnostic): string
-         prefix: string|{string, string}|function(diagnostic: Diagnostic, i: integer, total: integer): string, string|nil
+         prefix: string|{string, string}|function(diagnostic: Diagnostic, i: integer, total: integer): string, string
       end
       record SetLocListOpts
          namespace: integer
@@ -364,11 +364,11 @@ global record vim
          title: string
          severity: integer -- vim.diagnostic.severity
       end
-      config: function(opts: ConfigOpts, namespace: integer|nil)
-      disable: function(bufnr: integer|nil, namespace: integer|nil)
-      enable: function(bufnr: integer|nil, namespace: integer|nil)
+      config: function(opts: ConfigOpts, namespace: integer)
+      disable: function(bufnr: integer, namespace: integer)
+      enable: function(bufnr: integer, namespace: integer)
       fromqflist: function(list: {any}): {Diagnostic}
-      get: function(bufnr: integer|nil, opts: GetOpts)
+      get: function(bufnr: integer, opts: GetOpts)
       get_namespace: function(namespace: integer): {string:integer}
       get_namespace: function(namespace: integer): {{string:integer}}
       get_next: function(opts: GotoOpts): Diagnostic
@@ -377,14 +377,14 @@ global record vim
       get_prev_pos: function(opts: GotoOpts): {integer, integer}
       goto_next: function(opts: GotoOpts)
       goto_prev: function(opts: GotoOpts)
-      hide: function(namespace: integer|nil, bufnr: integer|nil)
-      match: function(str: string, pat: string, groups: {string}, severity_map: {string:string}, defaults: {string:any}): Diagnostic|nil
-      open_float: function(bufnr: integer|nil, opts: OpenFloatOpts): {integer, integer}
-      reset: function(namespace: integer|nil, bufnr: integer|nil)
-      set: function(namespace: integer, bufnr: integer, diagnostics: {Diagnostic}, opts: ConfigOpts|nil)
+      hide: function(namespace: integer, bufnr: integer)
+      match: function(str: string, pat: string, groups: {string}, severity_map: {string:string}, defaults: {string:any}): Diagnostic
+      open_float: function(bufnr: integer, opts: OpenFloatOpts): {integer, integer}
+      reset: function(namespace: integer, bufnr: integer)
+      set: function(namespace: integer, bufnr: integer, diagnostics: {Diagnostic}, opts: ConfigOpts)
       setloclist: function(opts: SetLocListOpts)
       setqflist: function(opts: SetQfListOpts)
-      show: function(namespace: integer|nil, bufnr: integer|nil, diagnostics: {Diagnostic}|nil, opts: ConfigOpts|nil)
+      show: function(namespace: integer, bufnr: integer, diagnostics: {Diagnostic}, opts: ConfigOpts)
       toqflist: function({Diagnostic}): {string:any}
    end
 


### PR DESCRIPTION
This mostly adds the new neovim 0.6 diagnostic api, but also the following:
- `vim.cmd`
- `vim.call`
- `vim.log.levels`
- `vim.notify`
- `vim.tbl_deep_extend`
- `vim.tbl_filter`
- `vim.list_slice`
- `vim.json`
  - `encode`
  - `decode`
- some generated ones

I also added some alternative signatures to `vim.tbl_extend` and `vim.list_extend` to make it a bit nicer to use.