### PR TITLE
Support array of TypeName in vim.validate

### DIFF
--- a/types/neovim/template
+++ b/types/neovim/template
@@ -136,7 +136,7 @@ global record vim
       "userdata"
    end
    -- Technically, this should be a union of tuples since the types are dependent and this allows for invalid combos
-   validate: function({string:{any, TypeName | function(any): (boolean, string), boolean | string}})
+   validate: function({string:{any, TypeName | {TypeName} | function(any): (boolean, string), boolean | string}})
    -- should be {string:{any, TypeName, boolean} | {any, function(any): (boolean, string)}, string}}
 
    record Regex


### PR DESCRIPTION
From `:h vim.validate`, it supports passing an array of type names if multiple are supported.