### PR TITLE
Update lualogging types definitions to release 1.7.0

### DIFF
--- a/types/lualogging/logging.d.tl
+++ b/types/lualogging/logging.d.tl
@@ -47,6 +47,7 @@ local record logging
 
    new: function(append: function(self: Log, level: Level, msg: string | function), startLevel: Level): Log
    buildLogPatterns: function(patterns: table, default: string): table
+   date: function(format: string, time: integer | string): string
    defaultLogPatterns: function(patt: string | table): table
    defaultTimestampPattern: function(patt: string): string
    defaultLevel: function(level: Level): Level


### PR DESCRIPTION
Add new API from release 1.7.0.

See:
- https://github.com/lunarmodules/lualogging/releases/tag/v1.7.0
- https://lunarmodules.github.io/lualogging/index.html#history

Note: There is also a new Appender in this release, but as discussed in #38, it can be added later by someone that needs it.