### PR TITLE
Added LuaJIT APIs

### DIFF
--- a/types/luajit/ffi.d.tl
+++ b/types/luajit/ffi.d.tl
@@ -1,0 +1,31 @@
+
+local record libffi
+    type CData = integer | number | string | { string | integer : CData } | nil
+    type CType = string | CData
+    type CFunction = function(...: any): CData
+    type CNamespace = { string : CFunction | CData }
+
+    load:       function(string): { string : CFunction | CData }
+    load:       function<T>(string): T
+    cdef:       function(string)
+    new:        function(CType, integer | nil, ...: any): CData
+    typeof:     function(CType, ...: any): CType
+    cast:       function(CType, ...: any): CType
+    metatype:   function(CType, metatable): CType
+    gc:         function(CData, function(CData)): CData
+    sizeof:     function(CType, integer | nil): integer | nil
+    alignof:    function(CType): integer
+    offsetof:   function(CType, string): integer, integer | nil, integer | nil
+    istype:     function(CType, any): boolean
+    errno:      function(integer | nil): integer
+    string:     function(CData, integer | nil): string
+    copy:       function(CData, CData, integer)
+    copy:       function(CData, string)
+    fill:       function(CData, integer, CData)
+    abi:        function(string): boolean
+    set:        function(function)
+
+    C: CNamespace
+end
+
+return libffi

--- a/types/luajit/jit.d.tl
+++ b/types/luajit/jit.d.tl
@@ -1,0 +1,10 @@
+local record jit
+    on:     function(function | boolean, boolean | nil)
+    off:    function(function | boolean, boolean | nil)
+    flush:  function(function | boolean, boolean | nil)
+
+    --Status
+    status: function(): boolean, string...
+end
+
+return jit

--- a/types/luajit/string/buffer.d.tl
+++ b/types/luajit/string/buffer.d.tl
@@ -1,0 +1,40 @@
+local ffi = require("ffi")
+
+local record StringBuffer
+    record SerialisationOptions
+        record IStringable
+            metamethod __tostring: function(IStringable): string
+        end
+
+        dict:       {string}
+        metatable:  {metatable<IStringable>}
+    end
+
+    type Data = string | number | SerialisationOptions.IStringable
+
+    new:        function(integer | nil, SerialisationOptions | nil): StringBuffer
+    put:        function(StringBuffer, Data, ...: Data): StringBuffer
+    putf:       function(StringBuffer, string, ...: Data): StringBuffer
+    putcdata:   function(StringBuffer, ffi.CData, integer): StringBuffer
+    set:        function(StringBuffer, Data)
+    set:        function(StringBuffer, ffi.CData, integer)
+    reset:      function(StringBuffer): StringBuffer
+    free:       function(StringBuffer)
+    reserve:    function(StringBuffer, integer): ffi.CData, integer
+    commit:     function(StringBuffer, integer): StringBuffer
+    skip:       function(StringBuffer, integer): StringBuffer
+    get:        function(StringBuffer, integer | nil, ...: integer): string...
+    tostring:   function(StringBuffer): string
+
+    ref:        function(StringBuffer): ffi.CData
+    encode:     function(StringBuffer, Data): StringBuffer
+    decode:     function(StringBuffer): Data | nil
+
+    encode:     function(Data): string
+    decode:     function(string): Data | nil
+
+    metamethod __tostring: function(StringBuffer): string
+    metamethod __call: function(StringBuffer): string
+end
+
+return StringBuffer

--- a/types/luajit/table/clear.d.tl
+++ b/types/luajit/table/clear.d.tl
@@ -1,0 +1,1 @@
+return function(tab: table) end

--- a/types/luajit/table/new.d.tl
+++ b/types/luajit/table/new.d.tl
@@ -1,0 +1,1 @@
+return function(narray: integer, nhash: integer): table end


### PR DESCRIPTION
These are present in LuaJIT.

I would like to add the entirety of `libc` as the type of `ffi.C`, but I would need to parse a standards conformant `libc.h` which I have not come across. Another issue was making sure that only tables which had a metatable that had `__tostring` was available for the `string.buffer` type, but this was resolved.