### PR TITLE
Add types for baton, flux, log.lua. Change rxi-json-lua to be more specific

### DIFF
--- a/types/baton/baton.d.tl
+++ b/types/baton/baton.d.tl
@@ -1,0 +1,36 @@
+-- Depends on love definition from https://github.com/MikuAuahDark/love2d-tl
+
+local record baton
+	record Configuration
+		controls: {string:{string}}
+		pairs: {string:{string, string, string, string}}
+		joystick: love.joystick.Joystick
+		deadzone: number
+		squareDeadzone: boolean
+	end
+	
+	enum ActiveDevice
+		"kbm"
+		"joy"
+		"none"
+	end
+	
+	record Player
+		config: Configuration
+		
+		update: function(self: Player)
+		getRaw: function(self: Player, name: string): number
+		get: function(self: Player, name: string): number
+		get: function(self: Player, name: string): number, number
+		down: function(self: Player, name: string): boolean
+		pressed: function(self: Player, name: string): boolean
+		released: function(self: Player, name: string): boolean
+		
+		getActiveDevice: function(self: Player): ActiveDevice
+		_activeDevice: ActiveDevice
+	end
+	
+	new: function(config: Configuration): Player
+end
+
+return baton

--- a/types/flux/flux.d.tl
+++ b/types/flux/flux.d.tl
@@ -1,0 +1,57 @@
+local record flux
+	enum Easing
+		"linear"
+		"quadin"
+		"quadout"
+		"quadinout"
+		"cubicin"
+		"cubicout"
+		"cubicinout"
+		"quartin"
+		"quartout"
+		"quartinout"
+		"quintin"
+		"quintout"
+		"quintinout"
+		"expoin"
+		"expoout"
+		"expoinout"
+		"sinein"
+		"sineout"
+		"sineinout"
+		"circin"
+		"circout"
+		"circinout"
+		"backin"
+		"backout"
+		"backinout"
+		"elasticin"
+		"elasticout"
+		"elasticinout"
+	end
+	
+	record Tween<T>
+		ease: function(self: Tween<T>, type: Easing): Tween<T>
+		delay: function(self: Tween<T>, time: number): Tween<T>
+		onstart: function(self: Tween<T>, function()): Tween<T>
+		onupdate: function(self: Tween<T>, function()): Tween<T>
+		oncomplete: function(self: Tween<T>, function()): Tween<T>
+		after: function<U>(self: Tween<U>, time: number, vars: U): Tween<U>
+		after: function<U>(self: Tween<T>, obj: U, time: number, vars: U): Tween<T>
+		stop: function(self: Tween<T>)
+	end
+	
+	record Group
+		update: function(self: Group, deltatime: number)
+		to: function<K, V>(self: Group, obj: {K:V}, time: number, vars: {K:V}): Tween<{K:V}>
+		to: function<T>(self: Group, obj: T, time: number, vars: T): Tween<T>
+		-- group: function(self: Group): Group
+	end
+	
+	update: function(deltatime: number)
+	to: function<K, V>(obj: {K:V}, time: number, vars: {K:V}): Tween<{K:V}>
+	to: function<T>(obj: T, time: number, vars: T): Tween<T>
+	group: function(): Group
+end
+
+return flux

--- a/types/rxi-json-lua/json.d.tl
+++ b/types/rxi-json-lua/json.d.tl
@@ -1,9 +1,14 @@
 local record json
-    -- Returns a string representing value encoded in JSON.
-    encode: function(value: any): string
-
-    -- Returns a value representing the decoded JSON string.
-    decode: function(str: string): any
+	type Array = {Value}
+	type Object = {string:Value}
+	
+	-- Workaround for not being able to union Array and Object
+	type Mixed = {string|integer:Value}
+	
+	type Value = number | string | boolean | Mixed
+	
+	encode: function(value: Value): string
+	decode: function(str: string): Value
 end
 
 return json

--- a/types/rxi-json-lua/json.d.tl
+++ b/types/rxi-json-lua/json.d.tl
@@ -7,7 +7,16 @@ local record json
 	
 	type Value = number | string | boolean | Mixed
 	
-	encode: function(value: Value): string
+	-- For convenience, encode takes any type and may throw an error at runtime.
+	-- You can enforce correctness yourself by specifying types on variables or records.
+	--
+	-- For example:
+	--     local obj: json.Object = {value = 'data'}
+	--     local encoded = json.encode(obj)
+	
+	encode: function(value: any): string
+	-- encode: function(value: Value): string
+	
 	decode: function(str: string): Value
 end
 

--- a/types/rxi-log-lua/log.d.tl
+++ b/types/rxi-log-lua/log.d.tl
@@ -1,0 +1,24 @@
+local record log
+	enum Level
+		"trace"
+		"debug"
+		"info"
+		"warn"
+		"error"
+		"fatal"
+	end
+	type LogFunction = function(...: any)
+	
+	usecolor: boolean
+	outfile: string
+	level: Level
+	
+	trace: LogFunction
+	debug: LogFunction
+	info: LogFunction
+	warn: LogFunction
+	error: LogFunction
+	fatal: LogFunction
+end
+
+return log


### PR DESCRIPTION
Definitions for these libraries:
* https://github.com/tesselode/baton
* https://github.com/rxi/flux
* https://github.com/rxi/log.lua
* https://github.com/rxi/json.lua

I changed json.lua to use more specific types rather than `any`.
You can still force it to accept any value like so:
```lua
local json = require 'json'

local t: table = {value = 'data'}

local encoded = json.encode(t as json.Value)
local decoded = json.decode(encoded) as any
```