### PR TITLE
luv: make correct spawn() signature

### DIFF
--- a/types/inspect/inspect.d.tl
+++ b/types/inspect/inspect.d.tl
@@ -6,7 +6,7 @@ local record inspect
         process: function(item: any, path: {any}): any
     end
 
-    metamethod __call: function(self: inspect, value: any, options: InspectOptions): string
+    metamethod __call: function(self: inspect, value: any, options?: InspectOptions): string
 end
 
 return inspect

--- a/types/luv/luv.d.tl
+++ b/types/luv/luv.d.tl
@@ -1101,7 +1101,7 @@ local record uv
    -- 
    -- @return `uv_process_t userdata`, `integer`
    -- 
-   spawn:function(path:string, options:SpawnOptions, on_exit:function(integer)):Process, integer
+   spawn:function(path:string, options:SpawnOptions, on_exit:function(exit_status: integer, term_signal: integer)):Process, integer
 
    --- ## `uv_stream_t` — Stream handle
    -- 


### PR DESCRIPTION
Hello. I found that parameters in `spawn()` function of `luv` is not fully correct. There is only one typed argument that is return code. I suggest to add second argument `signal` and describe arguments names.
https://github.com/teal-language/teal-types/blob/97c0ed8c90d7133261df5fefbe1cade1e7b616da/types/luv/luv.d.tl#L1104