### PR TITLE
Update LFS API

### DIFF
--- a/types/luafilesystem/lfs.d.tl
+++ b/types/luafilesystem/lfs.d.tl
@@ -12,20 +12,43 @@ local record lfs
    end
 
    record Attributes
-      dev: number
-      ino: number
+      dev: integer
+      ino: integer
       mode: FileMode
-      nlink: number
-      uid: number
-      gid: number
-      rdev: number
-      access: number
-      modification: number
-      change: number
-      size: number
+      nlink: integer
+      uid: integer
+      gid: integer
+      rdev: integer
+      access: integer
+      modification: integer
+      change: integer
+      size: integer
       permissions: string
-      blocks: number
-      blksize: number
+      blocks: integer
+      blksize: integer
+   end
+
+   enum AttributeSelInt
+      "dev"
+      "ino"
+      "nlink"
+      "uid"
+      "gid"
+      "rdev"
+      "access"
+      "modification"
+      "change"
+      "size"
+      "blocks"
+      "blksize"
+   end
+
+   enum AttributeSelStr
+      "permissions"
+   end
+
+   enum AttributeSelFM
+      "mode"
    end
 
    enum OpenFileMode
@@ -39,43 +62,47 @@ local record lfs
    end
 
    record Lock
-      free: function()
+      free: function(self)
    end
 
-   dir: function(string): function(): string
+   record DirObj
+      next: function(self): string
+      close: function(self)
+   end
+
+   dir: function(string): function(DirObj): (string), DirObj, nil, DirObj
 
    chdir: function(string): boolean, string
 
-   lock_dir: function(string, number): Lock, string
+   lock_dir: function(string, ? integer): Lock, string
 
-   -- returns number on success, really!? this should be fixed in the lfs library
-   link: function(string, string, boolean): number, string
+   link: function(string, string, ? boolean): boolean, string
 
-   mkdir: function(string): boolean, string
+   mkdir: function(string): boolean, string, integer
 
-   rmdir: function(string): boolean, string
+   rmdir: function(string): boolean, string, integer
 
    setmode: function(string, OpenFileMode): boolean, string
 
-   currentdir: function(): string
+   currentdir: function(): string, string
 
    attributes: function(string): Attributes
-   attributes: function(string, string): string
-   attributes: function(string, string): number
-   attributes: function(string, string): FileMode
+   attributes: function(string, AttributeSelStr): string
+   attributes: function(string, AttributeSelInt): integer
+   attributes: function(string, AttributeSelFM): FileMode
    attributes: function(string, Attributes): Attributes
 
    symlinkattributes: function(string): Attributes
-   symlinkattributes: function(string, string): string
-   symlinkattributes: function(string, string): number
-   symlinkattributes: function(string, string): FileMode
+   symlinkattributes: function(string, AttributeSelStr): string
+   symlinkattributes: function(string, AttributeSelInt): integer
+   symlinkattributes: function(string, AttributeSelFM): FileMode
    symlinkattributes: function(string, Attributes): Attributes
 
-   touch: function(string, number, number): boolean, string
+   touch: function(string, ? integer, ? integer): boolean, string
 
    -- TODO: FILE needs to be renamed to io.FILE in tl itself
-   lock: function(FILE, LockMode, number, number): boolean, string
-   unlock: function(FILE, number, number): boolean, string
+   lock:   function(FILE, LockMode, ? integer, ? integer): boolean, string
+   unlock: function(FILE,           ? integer, ? integer): boolean, string
 
 end
 


### PR DESCRIPTION
Now uses integer for most attributes. `dir(path)` function actually returns four values for use with iterators. Also updated the attribute selection.