### PR TITLE
Update luafilesystem

### DIFF
--- a/types/luafilesystem/lfs.d.tl
+++ b/types/luafilesystem/lfs.d.tl
@@ -90,17 +90,17 @@ local record lfs
 
    currentdir: function(): string, string
 
-   attributes: function(string): Attributes
-   attributes: function(string, AttributeSelStr): string
-   attributes: function(string, AttributeSelInt): integer
-   attributes: function(string, AttributeSelFM): FileMode
-   attributes: function(string, Attributes): Attributes
+   attributes: function(string): Attributes, string, integer
+   attributes: function(string, AttributeSelStr): string, string, integer
+   attributes: function(string, AttributeSelInt): integer, string, integer
+   attributes: function(string, AttributeSelFM): FileMode, string, integer
+   attributes: function(string, Attributes): Attributes, string, integer
 
-   symlinkattributes: function(string): SymlinkAttributes
-   symlinkattributes: function(string, AttributeSelStr): string
-   symlinkattributes: function(string, AttributeSelInt): integer
-   symlinkattributes: function(string, AttributeSelFM): FileMode
-   symlinkattributes: function(string, SymlinkAttributes): SymlinkAttributes
+   symlinkattributes: function(string): SymlinkAttributes, string, integer
+   symlinkattributes: function(string, AttributeSelStr): string, string, integer
+   symlinkattributes: function(string, AttributeSelInt): integer, string, integer
+   symlinkattributes: function(string, AttributeSelFM): FileMode, string, integer
+   symlinkattributes: function(string, SymlinkAttributes): SymlinkAttributes, string, integer
 
    touch: function(string, ? integer, ? integer): boolean, string
 

--- a/types/luafilesystem/lfs.d.tl
+++ b/types/luafilesystem/lfs.d.tl
@@ -11,7 +11,7 @@ local record lfs
       "other"
    end
 
-   record Attributes
+   interface Attributes
       dev: integer
       ino: integer
       mode: FileMode
@@ -26,6 +26,10 @@ local record lfs
       permissions: string
       blocks: integer
       blksize: integer
+   end
+
+   interface SymlinkAttributes is Attributes
+      target: string
    end
 
    enum AttributeSelInt
@@ -92,11 +96,11 @@ local record lfs
    attributes: function(string, AttributeSelFM): FileMode
    attributes: function(string, Attributes): Attributes
 
-   symlinkattributes: function(string): Attributes
+   symlinkattributes: function(string): SymlinkAttributes
    symlinkattributes: function(string, AttributeSelStr): string
    symlinkattributes: function(string, AttributeSelInt): integer
    symlinkattributes: function(string, AttributeSelFM): FileMode
-   symlinkattributes: function(string, Attributes): Attributes
+   symlinkattributes: function(string, SymlinkAttributes): SymlinkAttributes
 
    touch: function(string, ? integer, ? integer): boolean, string
 


### PR DESCRIPTION
- Changes `Attributes` to be an interface and adds `SymlinkAttributes` as a sub-interface of that for `symlinkattributes`.
- Adds the error message and errno return values to `attributes` and `symlinkattributes`