### PR TITLE
Fix LuaJIT APIs to account for optional values

### DIFF
--- a/types/luajit/ffi.d.tl
+++ b/types/luajit/ffi.d.tl
@@ -1,6 +1,6 @@
 
 local record libffi
-    type CData = integer | number | string | { string | integer : CData } | nil
+    type CData = integer | number | string | { string | integer : CData }
     type CType = string | CData
     type CFunction = function(...: any): CData
     type CNamespace = { string : CFunction | CData }
@@ -8,17 +8,17 @@ local record libffi
     load:       function(string): { string : CFunction | CData }
     load:       function<T>(string): T
     cdef:       function(string)
-    new:        function(CType, integer | nil, ...: any): CData
+    new:        function(ct: CType, nelem?: integer, ...: any): CData
     typeof:     function(CType, ...: any): CType
     cast:       function(CType, ...: any): CType
     metatype:   function(CType, metatable): CType
     gc:         function(CData, function(CData)): CData
-    sizeof:     function(CType, integer | nil): integer | nil
+    sizeof:     function(ct: CType, nelem?: integer): integer | nil
     alignof:    function(CType): integer
     offsetof:   function(CType, string): integer, integer | nil, integer | nil
     istype:     function(CType, any): boolean
-    errno:      function(integer | nil): integer
-    string:     function(CData, integer | nil): string
+    errno:      function(newerr?: integer): integer
+    string:     function(ptr: CData, len?: integer): string
     copy:       function(CData, CData, integer)
     copy:       function(CData, string)
     fill:       function(CData, integer, CData)

--- a/types/luajit/string/buffer.d.tl
+++ b/types/luajit/string/buffer.d.tl
@@ -12,7 +12,8 @@ local record StringBuffer
 
     type Data = string | number | SerialisationOptions.IStringable
 
-    new:        function(integer | nil, SerialisationOptions | nil): StringBuffer
+    new:        function(size?: integer, options?: SerialisationOptions): StringBuffer
+    new:        function(options?: SerialisationOptions): StringBuffer
     put:        function(StringBuffer, Data, ...: Data): StringBuffer
     putf:       function(StringBuffer, string, ...: Data): StringBuffer
     putcdata:   function(StringBuffer, ffi.CData, integer): StringBuffer
@@ -23,7 +24,7 @@ local record StringBuffer
     reserve:    function(StringBuffer, integer): ffi.CData, integer
     commit:     function(StringBuffer, integer): StringBuffer
     skip:       function(StringBuffer, integer): StringBuffer
-    get:        function(StringBuffer, integer | nil, ...: integer): string...
+    get:        function(StringBuffer, len?: integer, ...: integer): string...
     tostring:   function(StringBuffer): string
 
     ref:        function(StringBuffer): ffi.CData


### PR DESCRIPTION
Rather than use `T | nil` for arguments, we now name arguments and mark them optional using `?`. This also requires adding the argument name, which makes for a better API.