### PR TITLE
dkjson: make some arguments optional and add more return values

### DIFF
--- a/types/dkjson/dkjson.d.tl
+++ b/types/dkjson/dkjson.d.tl
@@ -11,7 +11,7 @@ local record dkjson
       buffer: {string}
       bufferlen: number
       tables: {table:boolean}
-      exception: function(string, string, string, string): boolean|string, string
+      exception: function(reason: string, value: string, state: string, defaultmessage: string): boolean|string, string
    end
    encode: function(value: {string:any}, state?: JsonState): string
 
@@ -21,11 +21,11 @@ local record dkjson
 
    version: string
 
-   quotestring: function(string): string
+   quotestring: function(value: string): string
 
-   addnewline: function(JsonState)
+   addnewline: function(state: JsonState)
 
-   encodeexception: function(string, any, JsonState, string): string
+   encodeexception: function(reason: string, value: any, state: JsonState, defaultmessage: string): string
 
    use_lpeg: function(): dkjson
 end

--- a/types/dkjson/dkjson.d.tl
+++ b/types/dkjson/dkjson.d.tl
@@ -13,9 +13,9 @@ local record dkjson
       tables: {table:boolean}
       exception: function(string, string, string, string): boolean|string, string
    end
-   encode: function({string:any}, JsonState): string
+   encode: function(value: {string:any}, state?: JsonState): string
 
-   decode: function(string, number, any, table): {string:any}
+   decode: function(str: string, pos?: number, nullval?: any, objectmeta?: table, arraymeta?: table): {string:any}, number, string
 
    null: table
 


### PR DESCRIPTION
This makes some arguments in `dkjson.encode` and `dkjson.decode` optional, and adds more return values in `dkjson.decode`. The other functions have parameter names now.

I think this is a purely additive change and shouldn't break any existing code.