### PR TITLE
dkjson: fix JsonState.exception type and make json types more accurate

### DIFF
--- a/types/dkjson/dkjson.d.tl
+++ b/types/dkjson/dkjson.d.tl
@@ -8,7 +8,7 @@ local record dkjson
       | table | userdata  -- can always be valid with getmetatable(value).__tojson defined
 
    type OutputJsonValue = string | number | boolean
-      | {string|number : OutputJsonValue}
+      | {string|integer : OutputJsonValue}
 
    record JsonState
       indent: boolean

--- a/types/dkjson/dkjson.d.tl
+++ b/types/dkjson/dkjson.d.tl
@@ -4,8 +4,12 @@
 ]]
 
 local record dkjson
-   type InputJsonValue = string | number | boolean
-      | table | userdata  -- can always be valid with getmetatable(value).__tojson defined
+   interface InputJsonUserdata is userdata
+      where ((getmetatable(self) as table) or {}).__tojson
+   end
+
+   type InputJsonValue = string | number | boolean | InputJsonUserdata
+      | table  -- can always be valid with getmetatable(value).__tojson defined
 
    type OutputJsonValue = string | number | boolean
       | {string|integer : OutputJsonValue}

--- a/types/dkjson/dkjson.d.tl
+++ b/types/dkjson/dkjson.d.tl
@@ -4,6 +4,12 @@
 ]]
 
 local record dkjson
+   type InputJsonValue = string | number | boolean
+      | table | userdata  -- can always be valid with getmetatable(value).__tojson defined
+
+   type OutputJsonValue = string | number | boolean
+      | {string|number : OutputJsonValue}
+
    record JsonState
       indent: boolean
       keyorder: {string}
@@ -11,11 +17,12 @@ local record dkjson
       buffer: {string}
       bufferlen: number
       tables: {table:boolean}
-      exception: function(reason: string, value: any, state: JsonState, defaultmessage: string): string, string
+      exception: function(reason: string, value: InputJsonValue, state: JsonState, defaultmessage: string): string, string
    end
-   encode: function(value: {string:any}, state?: JsonState): string
 
-   decode: function(str: string, pos?: number, nullval?: any, objectmeta?: table, arraymeta?: table): {string:any}, number, string
+   encode: function(value: InputJsonValue, state?: JsonState): string
+
+   decode: function(str: string, pos?: number, nullval?: any, objectmeta?: table, arraymeta?: table): OutputJsonValue, number, string
 
    null: table
 
@@ -25,7 +32,7 @@ local record dkjson
 
    addnewline: function(state: JsonState)
 
-   encodeexception: function(reason: string, value: any, state: JsonState, defaultmessage: string): string, string
+   encodeexception: function(reason: string, value: InputJsonValue, state: JsonState, defaultmessage: string): string, string
 
    use_lpeg: function(): dkjson
 end

--- a/types/dkjson/dkjson.d.tl
+++ b/types/dkjson/dkjson.d.tl
@@ -25,7 +25,7 @@ local record dkjson
    end
    encode: function(value: InputJsonValue, state?: JsonState): string
 
-   decode: function(str: string, pos?: number, nullval?: any, objectmeta?: table, arraymeta?: table): OutputJsonValue, number, string
+   decode: function<Null>(str: string, pos?: number, nullval?: Null, objectmeta?: table, arraymeta?: table): OutputJsonValue | Null, number, string
 
    null: table
 

--- a/types/dkjson/dkjson.d.tl
+++ b/types/dkjson/dkjson.d.tl
@@ -11,7 +11,7 @@ local record dkjson
       buffer: {string}
       bufferlen: number
       tables: {table:boolean}
-      exception: function(reason: string, value: string, state: string, defaultmessage: string): boolean|string, string
+      exception: function(reason: string, value: any, state: JsonState, defaultmessage: string): string, string
    end
    encode: function(value: {string:any}, state?: JsonState): string
 
@@ -25,7 +25,7 @@ local record dkjson
 
    addnewline: function(state: JsonState)
 
-   encodeexception: function(reason: string, value: any, state: JsonState, defaultmessage: string): string
+   encodeexception: function(reason: string, value: any, state: JsonState, defaultmessage: string): string, string
 
    use_lpeg: function(): dkjson
 end

--- a/types/dkjson/dkjson.d.tl
+++ b/types/dkjson/dkjson.d.tl
@@ -19,7 +19,6 @@ local record dkjson
       tables: {table:boolean}
       exception: function(reason: string, value: InputJsonValue, state: JsonState, defaultmessage: string): string, string
    end
-
    encode: function(value: InputJsonValue, state?: JsonState): string
 
    decode: function(str: string, pos?: number, nullval?: any, objectmeta?: table, arraymeta?: table): OutputJsonValue, number, string


### PR DESCRIPTION
- Give `dkjson.JsonState.exception` the same type as `dkjson.encodeexception`
- Make `dkjson.encode` and `dkjson.JsonState.exception` parameter types more accurate
  - Create type `InputJsonValue` to represent encodable values
  - Create interface `InputJsonUserdata` to help guard encodable values
- Make `dkjson.decode` return type more accurate
  - Create type `OutputJsonValue` to represent possible decoded strings
  - Add type parameter `Null` for `nullval` argument